### PR TITLE
修复用https访问时，js和css资源URL仍为http的问题

### DIFF
--- a/include/player.php
+++ b/include/player.php
@@ -25,7 +25,7 @@ if ( !class_exists( 'wp_player_plugin' ) ){
             add_shortcode( 'player', array( $this, 'wp_player_shortcode' ) );
 
             $this->options = get_option( 'wp_player_options' );
-            $this->base_dir = WP_PLUGIN_URL.'/'. dirname( plugin_basename( dirname( __FILE__ ) ) ).'/';
+            $this->base_dir = plugin_dir_url( __FILE__ ) . '../';
             $this->admin_dir = site_url( '/wp-admin/options-general.php?page=player.php' );
             
         }


### PR DESCRIPTION
如果wordpress站点同时支持http和https，但是”设置“->”常规“里面地址设置的是http，此时用https访问，插件的css和js资源的URL仍为http。
